### PR TITLE
Disable regex search with --literal

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -116,6 +116,10 @@ Specify a delimiter when printing list formatters, default to 2 spaces. This
 option only has an effect when using the B<-ii> operation combined with
 B<--format>.  See the FORMATTING section.
 
+=item B<--literal>
+
+Disable regex search, interpret target as a literal string.
+
 =item B<--no-ignore-ood>
 
 The reverse of B<--ignore-ood>.

--- a/extra/bash_completion
+++ b/extra/bash_completion
@@ -19,7 +19,7 @@ _cower() {
   local cur=${COMP_WORDS[COMP_CWORD]} prev=${COMP_WORDS[COMP_CWORD - 1]} prevprev=${COMP_WORDS[COMP_CWORD - 2]}
 
   local shortopts=(-d -i -m -s -u -f -h -t -V -b -c -o -q -v)
-  local longopts=(--download --info --msearch --search --update --force --version
+  local longopts=(--download --info --msearch --search --update --force --version --literal
                   --brief --debug --ignore-ood --no-ignore-ood --quiet --verbose --by)
   local longoptsarg=(--ignore --ignorerepo --target --threads --timeout --color --format
                      --sort --rsort -listdelim)

--- a/src/cower.c
+++ b/src/cower.c
@@ -126,6 +126,7 @@ enum {
   OP_IGNOREPKG,
   OP_IGNOREREPO,
   OP_LISTDELIM,
+  OP_LITERAL,
   OP_THREADS,
   OP_TIMEOUT,
   OP_NOIGNOREOOD,
@@ -273,6 +274,7 @@ static struct {
   short sortorder;
   int force:1;
   int getdeps:1;
+  int literal:1;
   int quiet:1;
   int skiprepos:1;
   int frompkgbuild:1;
@@ -298,7 +300,7 @@ static struct {
 };
 
 int allow_regex() {
-  return cfg.opmask & OP_SEARCH && cfg.search_by != SEARCHBY_MAINTAINER;
+  return cfg.opmask & OP_SEARCH && !cfg.literal && cfg.search_by != SEARCHBY_MAINTAINER;
 }
 
 int streq(const char *s1, const char *s2) {
@@ -1123,6 +1125,7 @@ int parse_options(int argc, char *argv[]) {
     {"no-ignore-ood", no_argument,        0, OP_NOIGNOREOOD},
     {"ignorerepo",    optional_argument,  0, OP_IGNOREREPO},
     {"listdelim",     required_argument,  0, OP_LISTDELIM},
+    {"literal",       no_argument,        0, OP_LITERAL},
     {"quiet",         no_argument,        0, 'q'},
     {"target",        required_argument,  0, 't'},
     {"threads",       required_argument,  0, OP_THREADS},
@@ -1238,6 +1241,9 @@ int parse_options(int argc, char *argv[]) {
         break;
       case OP_LISTDELIM:
         cfg.delim = optarg;
+        break;
+      case OP_LITERAL:
+        cfg.literal |= 1;
         break;
       case OP_THREADS:
         cfg.maxthreads = strtol(optarg, &token, 10);
@@ -2060,6 +2066,7 @@ void usage(void) {
       "      --sort <key>          sort results in ascending order by key\n"
       "      --rsort <key>         sort results in descending order by key\n"
       "      --listdelim <delim>   change list format delimeter\n"
+      "      --literal             disable regex search, interpret target as a literal string\n"
       "  -q, --quiet               output less\n"
       "  -v, --verbose             output more\n\n");
 }


### PR DESCRIPTION
These options will help cower work seamlessly to search for packages with weird characters, such as blast+ or blast+-bin