### PR TITLE
Less verbose updates

### DIFF
--- a/src/cower.c
+++ b/src/cower.c
@@ -2011,11 +2011,18 @@ aurpkg_t **task_update(struct task_t *task, const char *arg) {
 
   num_packages = aur_packages_count(packages);
 
+  if (cfg.quiet) {
+    cwr_printf(LOG_VERBOSE, "Checking %d packages for updates...\n",
+      num_packages);
+  }
+
   for(i = 0; i < num_packages; ++i) {
     aurpkg_t *pkg = packages[i];
-
-    cwr_printf(LOG_VERBOSE, "Checking %s%s%s for updates...\n",
-      colstr.pkg, pkg->name, colstr.nc);
+    
+    if (!cfg.quiet) {
+        cwr_printf(LOG_VERBOSE, "Checking %s%s%s for updates...\n",
+          colstr.pkg, pkg->name, colstr.nc);
+    }
 
     pmpkg = alpm_db_get_pkg(db_local, pkg->name);
     if (!pmpkg) {

--- a/src/cower.c
+++ b/src/cower.c
@@ -2020,8 +2020,8 @@ aurpkg_t **task_update(struct task_t *task, const char *arg) {
     aurpkg_t *pkg = packages[i];
     
     if (!cfg.quiet) {
-        cwr_printf(LOG_VERBOSE, "Checking %s%s%s for updates...\n",
-          colstr.pkg, pkg->name, colstr.nc);
+      cwr_printf(LOG_VERBOSE, "Checking %s%s%s for updates...\n",
+        colstr.pkg, pkg->name, colstr.nc);
     }
 
     pmpkg = alpm_db_get_pkg(db_local, pkg->name);


### PR DESCRIPTION
Currently running cower with `cower -vdufq` produces the following output:
```
:: Checking bdf-tewi-git for updates...
:: Checking cower for updates...
:: Checking dep-git for updates...
:: firefox-beta-bin downloaded to /HDDStorage/source/aur
...
```

On a system with sufficient packages this makes it hard to sift through the output looking for which packages had updates and were downloaded.

This patch removes those `Checking...` messages when cower is run with `-q`

After apply this patch, running cower with the same flags outputs:
```
:: Checking 39 packages for updates...
:: firefox-beta-bin downloaded to /HDDStorage/source/aur
...
```

This could also be cleaned up by setting up the logger to not print verbose logs when the `q` flag is set. But I don't want to assume which log messages are important and which are not.